### PR TITLE
Correct syntax for SECTIONs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ A section has a name and optionally an unlimited amount of inner elements. In
 String representation a section is enclosed by easily distinguishable header
 and footer
 
-    # ----- BEGIN SECTION somename -----
+    # -----BEGIN SECTION somename-----
     # Elements here
-    # ----- END SECTION somename -----
+    # -----END SECTION somename-----
 
 A section is created by the following:
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ section.elements
 
 #### Empty element
 
-Also, to represent completly empty lines without abandoning their whitespace
+Also, to represent completely empty lines without abandoning their whitespace
 contents there is an EmptyElement.
 
 ~~~~~ ruby


### PR DESCRIPTION
This is the first time I've actually edited using GitHub web interface. I'm impressed at how much simpler it made forking and submitting a tiny change.

My SECTIONs were being detected as ordinary comments until I removed the spaces around the label. I've updated the README to reflect this change.
