### PR TITLE
Fixed syntax for comments in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ section.elements
 
 #### Empty element
 
-Also, to represent completly empty lines without abandoning their whitespace
+Also, to represent completely empty lines without abandoning their whitespace
 contents there is an EmptyElement.
 
 ~~~~~ ruby


### PR DESCRIPTION
My section elements were not being detected until I removed the spaces from around the section labels.
